### PR TITLE
Add Jaccard Distance logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/productreviews/models/Product.java
+++ b/src/main/java/com/productreviews/models/Product.java
@@ -1,11 +1,10 @@
 package com.productreviews.models;
 
 import com.productreviews.models.common.Category;
-import org.hibernate.annotations.GeneratorType;
 
+import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.*;
 
 /**
  * Product represents a minimal entity that has a name,
@@ -182,4 +181,5 @@ public class Product {
                 ", category=" + category +
                 '}';
     }
+
 }

--- a/src/main/java/com/productreviews/models/common/Category.java
+++ b/src/main/java/com/productreviews/models/common/Category.java
@@ -1,5 +1,10 @@
 package com.productreviews.models.common;
 
+/**
+ * The Category enum represents the possible categories a product can
+ * be included in. This is useful for sorting products by a specific
+ * category, such as products that are books and those that are not.
+ */
 public enum Category {
     BOOK("Book"), NOT_BOOK("Not Book");
 

--- a/src/test/java/models/TestProductModel.java
+++ b/src/test/java/models/TestProductModel.java
@@ -2,6 +2,7 @@ package models;
 
 import com.productreviews.models.Product;
 import com.productreviews.models.Review;
+import com.productreviews.models.common.Category;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,16 +35,19 @@ public class TestProductModel {
         String name = "Test";
         String description = "This is a test";
         String image = "image.png";
+        Category book = Category.BOOK;
 
         product.setId(id);
         product.setName(name);
         product.setDescription(description);
         product.setImage(image);
+        product.setCategory(book);
 
         assertEquals(id, product.getId());
         assertEquals(name, product.getName());
         assertEquals(description, product.getDescription());
         assertEquals(image, product.getImage());
+        assertEquals(book, product.getCategory());
     }
 
     /**
@@ -76,27 +80,40 @@ public class TestProductModel {
     public void testProductConstructors() {
         String name = "test";
         String image = "test.jpg";
+        String description = "this is a test";
+        Category book = Category.BOOK;
 
         Product product1 = new Product(name, image);
         Product product2 = new Product(name, image, 2L);
+        Product product3 = new Product(name, image, 2L, description, book);
 
         assertEquals(0, product.getId());
         assertNull(product.getImage());
         assertNull(product.getName());
         assertNull(product.getDescription());
         assertEquals(0, product.getReviews().size());
+        assertNull(product.getCategory());
 
         assertEquals(0, product1.getId());
         assertEquals(image, product1.getImage());
         assertEquals(name, product1.getName());
         assertNull(product1.getDescription());
         assertEquals(0, product1.getReviews().size());
+        assertNull(product.getCategory());
 
         assertEquals(2, product2.getId());
         assertEquals(image, product2.getImage());
         assertEquals(name, product2.getName());
         assertNull(product2.getDescription());
         assertEquals(0, product2.getReviews().size());
+        assertNull(product.getCategory());
+
+        assertEquals(2, product3.getId());
+        assertEquals(image, product3.getImage());
+        assertEquals(name, product3.getName());
+        assertEquals(description, product3.getDescription());
+        assertEquals(0, product3.getReviews().size());
+        assertEquals(book, product3.getCategory());
     }
 
 }

--- a/src/test/java/models/TestUserModel.java
+++ b/src/test/java/models/TestUserModel.java
@@ -1,5 +1,6 @@
 package models;
 
+import com.productreviews.models.Product;
 import com.productreviews.models.Review;
 import com.productreviews.models.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -118,5 +119,59 @@ public class TestUserModel {
         assertEquals(1, user3.getId());
         assertEquals(username, user3.getUsername());
         assertNull(user3.getPassword());
+    }
+
+    /**
+     * A test to exercise the Jaccard Distance calculations that
+     * can be performed between the review scores of one user
+     * and the review scores of another user.
+     */
+    @Test
+    public void testUserJaccardDistance() {
+        User user1 = new User("john", "john");
+        User user2 = new User("John2", "John2");
+
+        // Base case, both review lists are empty, so distance should be 0 by definition.
+        assertEquals(0, user1.getJaccardDistanceReviews(user2));
+        // Shouldn't matter which user is first
+        assertEquals(0, user2.getJaccardDistanceReviews(user1));
+
+        Product product = new Product();
+        Product product2 = new Product();
+        Review rev1 = new Review(user1, product, 4, "Cool");
+        Review rev2 = new Review(user2, product, 5, "Nice");
+        Review rev3 = new Review(user1, product, 1, "not nice");
+        Review rev4 = new Review(user1, product2, 1, "also not nice");
+        Review rev5 = new Review(user2, product2, 4, "It's alright");
+        Review rev6 = new Review(user2, product2, 1, "It's bad");
+        Review rev7 = new Review(user2, product2, 2, "Not good");
+        user1.addReview(rev1);
+        user1.addReview(rev3);
+        user1.addReview(rev4);
+        user2.addReview(rev2);
+        user2.addReview(rev5);
+        user2.addReview(rev6);
+
+        // Assert Jaccard distance is what is expected.
+        assertEquals(0.5, user1.getJaccardDistanceReviews(user2));
+        assertEquals(0.5, user2.getJaccardDistanceReviews(user1));
+
+        // Modify the review lists and try again.
+        user2.addReview(rev7);
+
+        assertEquals(0.6, user1.getJaccardDistanceReviews(user2));
+        assertEquals(0.6, user2.getJaccardDistanceReviews(user1));
+
+        // Try for two identical review sets
+        user2.addReview(rev1);
+        user2.addReview(rev3);
+        user2.addReview(rev4);
+        user1.addReview(rev2);
+        user1.addReview(rev5);
+        user1.addReview(rev6);
+        user1.addReview(rev7);
+
+        assertEquals(0.0, user1.getJaccardDistanceReviews(user2));
+        assertEquals(0.0, user2.getJaccardDistanceReviews(user1));
     }
 }


### PR DESCRIPTION
Partially addresses #21, but does not close it. This logic should be added as a sorting option for reviews once that functionality has been added to the application.
- Adds Jaccard distance calculation logic for users to determine similarity based on review scores. Because reviews are not unique, we make use of Multisets, but the overall Jaccard Index calculation is unaffected by this because we ignore the repeated element unless they repeat in both sets.
- Update the tests for the User Model and the Product Model
  - User Model tests now perform Jaccard distance calculation verification
  - Product has new tests to deal with the addition of categories
- Wrote a JavaDoc for the Category enum, which should be updated once new categories get added.
- Multisets are apart of Google Guava. A new dependency has been added to the pom file to import this dependency into the application.